### PR TITLE
feat(workflow): auto-apply 'members' label to qualifying issues

### DIFF
--- a/.github/workflows/issue-add-member.yml
+++ b/.github/workflows/issue-add-member.yml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   from-issue:
-    if: contains(github.event.issue.labels.*.name, 'members') && github.event.issue.state == 'open'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -16,6 +15,24 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Ensure 'members' label (if issue looks like member form)
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            if (!issue || issue.state !== 'open') return;
+            const labels = (issue.labels || []).map(l => typeof l === 'string' ? l : l.name);
+            const body = issue.body || '';
+            const looksLikeForm = /Full name/i.test(body) && /(Image URL|repo path|image\s*:)/i.test(body);
+            if (!labels.includes('members') && looksLikeForm) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: ['members']
+              });
+            }
 
       - name: Parse issue form
         id: parse


### PR DESCRIPTION
## Member Card Request

Fill the block below between the markers. This PR will trigger a GitHub Action to create `src/content/members/<slug>.md` and download the image into `src/assets/members/` when possible.

<!-- MEMBER-INFO-START -->
```yaml
name: ""
role: ""
affiliation: ""
# EITHER a remote URL OR a local repo path under src/assets/members/
image: "https://avatars.githubusercontent.com/u/59738610?v=4"
website: ""
order: 100
```
<!-- MEMBER-INFO-END -->

### Checklist

- [ ] I consent to having my name, role, affiliation, and image listed on the site.
- [ ] If supplying a local image, I confirm I have added it under `src/assets/members/` and referenced it via a relative path.


